### PR TITLE
Fix wrong path to embedded certificate

### DIFF
--- a/tangocard.js
+++ b/tangocard.js
@@ -1,7 +1,8 @@
 var request = require('request')
-  , fs = require('fs');
+  , fs = require('fs')
+  , path = require('path');
 
-var certContent = fs.readFileSync('ca_cert/digicert_chain.pem');
+var certContent = fs.readFileSync(path.join(__dirname, 'ca_cert', 'digicert_chain.pem'));
 
 module.exports = function(options) {
   var token = new Buffer(options.name + ':' + options.key).toString('base64')


### PR DESCRIPTION
Using node-tangocard as a dependency in another project was causing a non existent file error due to the absolute path for the embedded certificate. With this change the path is relative to the script file requesting it.
